### PR TITLE
Fix typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@ Located in the beautiful village of
 	<span itemprop="address">Speicher</span>,
 	<span itemprop="nationality">Switzerland</span>.
 </a>
-Working as CISO at <a href="https://erlef.org/">Erlang Ecosytsem Foundation</a> and
+Working as CISO at <a href="https://erlef.org/">Erlang Ecosystem Foundation</a> and
 Technical Advisor to <a href="https://sustema.io">Sustema AG</a>.
 <section>
 	<h2>


### PR DESCRIPTION
💁 This change fixes a small typo in the name "Erlang Ecosystem Foundation". Thanks for your work!